### PR TITLE
More checks

### DIFF
--- a/programs/multisig/src/lib.rs
+++ b/programs/multisig/src/lib.rs
@@ -149,8 +149,8 @@ pub mod mean_multisig {
         title: String,
         description: String,
         expiration_date: u64,
-        pda_timestamp: u64,
-        pda_bump: u8
+        _pda_timestamp: u64, // deprecated
+        _pda_bump: u8 // deprecated
 
     ) -> Result<()> {
 
@@ -180,9 +180,6 @@ pub mod mean_multisig {
         tx.operation = operation;
         // tx.keypairs = keypairs; // deprecated
         tx.proposer = ctx.accounts.proposer.key();
-        // These two fields are optional since not all transactions create a new account
-        tx.pda_timestamp = pda_timestamp;
-        tx.pda_bump = pda_bump;
 
         let tx_detail = &mut ctx.accounts.transaction_detail;
         // Save transaction detail
@@ -724,8 +721,10 @@ pub struct Transaction {
     pub keypairs: Vec<[u8; 64]>,
     /// The proposer of the transaction
     pub proposer: Pubkey,
+    #[deprecated]
     /// The timestamp used as part of the seed of the PDA account
     pub pda_timestamp: u64,
+    #[deprecated]
     /// The bump used to derive the PDA account
     pub pda_bump: u8
 }

--- a/programs/multisig/src/lib.rs
+++ b/programs/multisig/src/lib.rs
@@ -626,41 +626,6 @@ pub struct ExecuteTransaction<'info> {
 }
 
 #[derive(Accounts)]
-pub struct ExecuteTransactionPda<'info> {
-    #[account(
-        mut,
-        constraint = multisig.owner_set_seqno == transaction.owner_set_seqno @ ErrorCode::InvalidOwnerSetSeqNumber
-    )]
-    multisig: Box<Account<'info, MultisigV2>>,
-    /// CHECK: multisig_signer is a PDA program signer. Data is never read or written to
-    #[account(
-        seeds = [multisig.key().as_ref()],
-        bump = multisig.nonce,
-    )]
-    multisig_signer: UncheckedAccount<'info>,
-    /// CHECK: pda_account is a PDA program signer. Data is never read or written to
-    #[account(
-        mut,
-        seeds = [multisig.key().as_ref(), &transaction.pda_timestamp.to_le_bytes()],
-        bump = transaction.pda_bump,
-    )]
-    pda_account: UncheckedAccount<'info>,
-    #[account(mut, has_one = multisig)]
-    transaction: Box<Account<'info, Transaction>>,
-    #[account(
-        init_if_needed,
-        payer = payer,
-        seeds = [multisig.key().as_ref(), transaction.key().as_ref()],
-        bump,
-        space = 8 + 584 // discriminator + account size
-    )]
-    transaction_detail: Box<Account<'info, TransactionDetail>>,
-    #[account(mut)]
-    payer: Signer<'info>,
-    system_program: Program<'info, System>
-}
-
-#[derive(Accounts)]
 pub struct InitSettings<'info> {
     #[account(mut)]
     payer: Signer<'info>,

--- a/programs/multisig/src/lib.rs
+++ b/programs/multisig/src/lib.rs
@@ -21,6 +21,10 @@ use anchor_lang::prelude::*;
 use anchor_lang::solana_program::instruction::Instruction;
 use std::ops::Deref;
 
+pub mod account_replacement_placeholder {
+    anchor_lang::declare_id!("NewPubkey1111111111111111111111111111111111");
+}
+
 #[cfg(feature = "devnet")]
 declare_id!("MMSdTDhtwBs2w4MxGCbqfWLgerMQNbXazizghoh7uMJ");
 #[cfg(not(feature = "devnet"))]
@@ -341,7 +345,10 @@ pub mod mean_multisig {
     }
 
     /// Executes the given transaction if threshold owners have signed it.
-    pub fn execute_transaction_pda(ctx: Context<ExecuteTransactionPda>) -> Result<()> {
+    pub fn execute_transaction_with_replacements(
+        ctx: Context<ExecuteTransaction>,
+        replacement_accounts: Vec<Pubkey>
+    ) -> Result<()> {
 
         // Has this been executed already?
         if ctx.accounts.transaction.executed_on > 0 {
@@ -352,7 +359,7 @@ pub mod mean_multisig {
         let now = Clock::get()?.unix_timestamp as u64;
 
         if ctx.accounts.transaction_detail.expiration_date > 0 && 
-           ctx.accounts.transaction_detail.expiration_date < now 
+        ctx.accounts.transaction_detail.expiration_date < now 
         {
             return Err(ErrorCode::AlreadyExpired.into());
         }
@@ -372,35 +379,37 @@ pub mod mean_multisig {
 
         // Execute the transaction signed by the multisig.
         let mut ix: Instruction = (*ctx.accounts.transaction).deref().into();
-        ix.accounts = ix
-            .accounts
-            .iter()
-            .map(|acc| {
-                let mut acc = acc.clone();
-                if &acc.pubkey == ctx.accounts.multisig_signer.to_account_info().key ||
-                   &acc.pubkey == ctx.accounts.pda_account.to_account_info().key 
-                {
-                    acc.is_signer = true;
+        let mut last_replacement_account_index_used = 0;
+        let mut mapped_accounts = vec!();
+        
+        for acc in ix.accounts.iter() {
+            let mut acc = acc.clone();
+            if &acc.pubkey == ctx.accounts.multisig_signer.to_account_info().key {
+                acc.is_signer = true;
+            } else if acc.pubkey == account_replacement_placeholder::ID {
+                if last_replacement_account_index_used == replacement_accounts.len() {
+                    return Err(ErrorCode::NotEnoughReplacementAccounts.into());
                 }
-                acc
-            })
-            .collect();
+                let replacement_account = replacement_accounts
+                    .get(last_replacement_account_index_used)
+                    .unwrap();
+                acc.pubkey = *replacement_account;
+                acc.is_signer = true;
+                last_replacement_account_index_used = last_replacement_account_index_used + 1;
+            }
+            mapped_accounts.push(acc);
+        }
+        ix.accounts = mapped_accounts;
 
-        let transaction_seeds = &[
+        let seeds = &[
             ctx.accounts.multisig.to_account_info().key.as_ref(),            
             &[ctx.accounts.multisig.nonce],
         ];
 
-        let pda_seeds = &[
-            ctx.accounts.multisig.to_account_info().key.as_ref(),
-            &ctx.accounts.transaction.pda_timestamp.to_le_bytes(),
-            &[ctx.accounts.transaction.pda_bump],
-        ];
-
-        let signers = &[&transaction_seeds[..], &pda_seeds[..]];
+        let signer = &[&seeds[..]];
         let accounts = ctx.remaining_accounts;
-        let _ = solana_program::program::invoke_signed(&ix, accounts, signers)?;
-        let _ = ctx.accounts.multisig.reload()?;
+        solana_program::program::invoke_signed(&ix, accounts, signer)?;
+        ctx.accounts.multisig.reload()?;
         // Burn the transaction to ensure one time use.
         ctx.accounts.transaction.executed_on = Clock::get()?.unix_timestamp as u64;
 
@@ -904,5 +913,7 @@ pub enum ErrorCode {
     #[msg("Multisig account is not valid.")]
     InvalidMultisig,
     #[msg("Invalid settings authority.")]
-    InvalidSettingsAuthority
+    InvalidSettingsAuthority,
+    #[msg("Not enough replacement accounts.")]
+    NotEnoughReplacementAccounts
 }

--- a/programs/multisig/src/lib.rs
+++ b/programs/multisig/src/lib.rs
@@ -41,6 +41,16 @@ pub mod mean_multisig {
 
     ) -> Result<()> {
 
+        let (_expected_signer_address, expected_bump) =
+            Pubkey::find_program_address(
+                &[ctx.accounts.multisig.key().to_bytes().as_ref()],
+                ctx.program_id
+            );
+
+        if expected_bump != nonce {
+            return Err(ErrorCode::InvalidMultisigNonce.into());
+        }
+
         assert_unique_owners(&owners)?;
         require!(threshold > 0 && threshold <= owners.len() as u64, InvalidThreshold);
         require!(owners.len() > 0 && owners.len() <= 10, InvalidOwnersLen);

--- a/programs/multisig/src/lib.rs
+++ b/programs/multisig/src/lib.rs
@@ -595,7 +595,7 @@ pub struct ExecuteTransaction<'info> {
         constraint = multisig.owner_set_seqno == transaction.owner_set_seqno @ ErrorCode::InvalidOwnerSetSeqNumber
     )]
     multisig: Box<Account<'info, MultisigV2>>,
-    /// CHECK: `doc comment explaining why no checks through types are necessary`
+    /// CHECK: multisig_signer is a PDA program signer. Data is never read or written to
     #[account(
         seeds = [multisig.key().as_ref()],
         bump = multisig.nonce,
@@ -618,19 +618,18 @@ pub struct ExecuteTransaction<'info> {
 
 #[derive(Accounts)]
 pub struct ExecuteTransactionPda<'info> {
-    /// CHECK: multisig_signer is a PDA program signer. Data is never read or written to
     #[account(
         mut,
         constraint = multisig.owner_set_seqno == transaction.owner_set_seqno @ ErrorCode::InvalidOwnerSetSeqNumber
     )]
     multisig: Box<Account<'info, MultisigV2>>,
-    /// CHECK: `doc comment explaining why no checks through types are necessary`
+    /// CHECK: multisig_signer is a PDA program signer. Data is never read or written to
     #[account(
         seeds = [multisig.key().as_ref()],
         bump = multisig.nonce,
     )]
     multisig_signer: UncheckedAccount<'info>,
-    /// CHECK: `doc comment explaining why no checks through types are necessary`
+    /// CHECK: pda_account is a PDA program signer. Data is never read or written to
     #[account(
         mut,
         seeds = [multisig.key().as_ref(), &transaction.pda_timestamp.to_le_bytes()],

--- a/tests/multisig.ts
+++ b/tests/multisig.ts
@@ -25,6 +25,7 @@ type TransactionAccount = anchor.IdlTypes<MeanMultisig>["TransactionAccount"];
 type Owner = anchor.IdlTypes<MeanMultisig>["Owner"];
 
 const MEAN_MULTISIG_OPS = new PublicKey("3TD6SWY9M1mLY2kZWJNavPLhwXvcRsWdnZLRaMzERJBw");
+const ACCOUNT_REPLACEMENT_PLACEHOLDER = new PublicKey("NewPubkey1111111111111111111111111111111111");
 
 describe("multisig", async () => {
 
@@ -38,7 +39,7 @@ describe("multisig", async () => {
 
     const payer = (program.provider as AnchorProvider).wallet.publicKey;
     setupInfo.push({ name: "PAYER", pubkey: payer });
-    
+
     const [settings] = await PublicKey.findProgramAddress([Buffer.from(anchor.utils.bytes.utf8.encode("settings"))], program.programId);
     setupInfo.push({ name: "SETTINGS", pubkey: settings });
 
@@ -305,7 +306,7 @@ describe("multisig", async () => {
                         commitment: 'confirmed',
                     }
                 );
-                assert.fail("The statements above should fail");
+            assert.fail("The statements above should fail");
         } catch (error) {
             // console.log(error);
             expectedError = error as AnchorError;
@@ -437,7 +438,7 @@ describe("multisig", async () => {
             program.programId
         );
         // console.log(`canonical bump: ${nonce}`);
-        
+
         // find next possible bump
         let nextBump = nonce - 1;
         for (nextBump; nextBump >= 0; nextBump--) {
@@ -455,7 +456,7 @@ describe("multisig", async () => {
             }
         }
 
-        if(nextBump < 0) {
+        if (nextBump < 0) {
             assert.fail("Could not find next bump");
         }
 
@@ -464,16 +465,16 @@ describe("multisig", async () => {
         try {
             // create multisig
             await program.methods
-            .createMultisig(owners, new BN(threshold), nextBump, label)
-            .accounts({
-                proposer: owner1Key.publicKey,
-                multisig: multisigKey.publicKey,
-                settings,
-                opsAccount: MEAN_MULTISIG_OPS,
-                systemProgram: SystemProgram.programId,
-            })
-            .signers([owner1Key, multisigKey])
-            .rpc();
+                .createMultisig(owners, new BN(threshold), nextBump, label)
+                .accounts({
+                    proposer: owner1Key.publicKey,
+                    multisig: multisigKey.publicKey,
+                    settings,
+                    opsAccount: MEAN_MULTISIG_OPS,
+                    systemProgram: SystemProgram.programId,
+                })
+                .signers([owner1Key, multisigKey])
+                .rpc();
             assert.fail("The statements above should fail");
         } catch (error) {
             // console.log(error);
@@ -523,7 +524,7 @@ describe("multisig", async () => {
             }
         }
 
-        if(nextBump < 0) {
+        if (nextBump < 0) {
             assert.fail("Could not find next bump");
         }
 
@@ -532,16 +533,16 @@ describe("multisig", async () => {
         try {
             // create multisig
             await program.methods
-            .createMultisig(owners, new BN(threshold), nextBump, label)
-            .accounts({
-                proposer: owner1Key.publicKey,
-                multisig: multisigKey.publicKey,
-                settings,
-                opsAccount: MEAN_MULTISIG_OPS,
-                systemProgram: SystemProgram.programId,
-            })
-            .signers([owner1Key, multisigKey])
-            .rpc();
+                .createMultisig(owners, new BN(threshold), nextBump, label)
+                .accounts({
+                    proposer: owner1Key.publicKey,
+                    multisig: multisigKey.publicKey,
+                    settings,
+                    opsAccount: MEAN_MULTISIG_OPS,
+                    systemProgram: SystemProgram.programId,
+                })
+                .signers([owner1Key, multisigKey])
+                .rpc();
             assert.fail("The statements above should fail");
         } catch (error) {
             // console.log(error);
@@ -553,7 +554,350 @@ describe("multisig", async () => {
         assert.equal(expectedError?.error.errorMessage, 'Multisig nonce is not valid.');
     });
 
-    it("updates settings",async () => {
+    it("creates proposal with replacements", async () => {
+
+        const multisig = Keypair.generate();
+        const transaction = Keypair.generate();
+        const [txDetailAddress] = await PublicKey.findProgramAddress(
+            [multisig.publicKey.toBuffer(), transaction.publicKey.toBuffer()],
+            program.programId
+        );
+        const owner1Key = Keypair.generate();
+        await fundWallet(provider, owner1Key);
+        const label = 'Test';
+        const threshold = new BN(1);
+        const owners = [
+            {
+                address: owner1Key.publicKey,
+                name: "owner1"
+            },
+        ];
+        const [multisigSigner, nonce] = await PublicKey.findProgramAddress(
+            [multisig.publicKey.toBuffer()],
+            program.programId
+        );
+
+        // create transaction with multiple instructions
+        const rent = await provider.connection.getMinimumBalanceForRentExemption(100);
+
+        const ix1 = SystemProgram.createAccount({
+            /** The account that will transfer lamports to the created account */
+            fromPubkey: provider.wallet.publicKey,
+            /** Public key of the created account */
+            newAccountPubkey: ACCOUNT_REPLACEMENT_PLACEHOLDER,
+            /** Amount of lamports to transfer to the created account */
+            lamports: rent,
+            /** Amount of space in bytes to allocate to the created account */
+            space: 100,
+            /** Public key of the program to assign as the owner of the created account */
+            programId: SystemProgram.programId
+        });
+
+        const txSize = 1200;
+        const createIx = await program.account.transaction.createInstruction(
+            transaction,
+            txSize
+        );
+
+        const title = 'Test transaction';
+        const description = "This is a test transaction";
+        const operation = 1;
+
+        try {
+
+            // create multisig
+            await program.methods
+                .createMultisig(owners, new BN(threshold), nonce, label)
+                .accounts({
+                    proposer: owner1Key.publicKey,
+                    multisig: multisig.publicKey,
+                    settings,
+                    opsAccount: MEAN_MULTISIG_OPS,
+                    systemProgram: SystemProgram.programId,
+                })
+                .signers([owner1Key, multisig])
+                .rpc();
+
+            // create proposal
+            await program.methods
+                .createTransaction(
+                    ix1.programId,
+                    ix1.keys.map(key => ({ pubkey: key.pubkey, isSigner: key.isSigner, isWritable: key.isWritable })),
+                    ix1.data,
+                    operation,
+                    title,
+                    description,
+                    new BN((new Date().getTime() / 1000) + 3600),
+                    new BN(0),
+                    255
+                )
+                .preInstructions([createIx])
+                .accounts({
+                    multisig: multisig.publicKey,
+                    transaction: transaction.publicKey,
+                    transactionDetail: txDetailAddress,
+                    proposer: owner1Key.publicKey,
+                    settings,
+                    opsAccount: MEAN_MULTISIG_OPS,
+                    systemProgram: SystemProgram.programId,
+                })
+                .signers([transaction, owner1Key])
+                .rpc({
+                    commitment: 'confirmed',
+                });
+
+            // approve proposal
+            await program.methods
+                .approve()
+                .accounts({
+                    multisig: multisig.publicKey,
+                    transaction: transaction.publicKey,
+                    transactionDetail: txDetailAddress,
+                    owner: owner1Key.publicKey,
+                    systemProgram: SystemProgram.programId,
+                })
+                .signers([owner1Key])
+                .rpc(
+                    {
+                        commitment: 'confirmed',
+                    }
+                );
+
+            // execute proposal tx with replacements
+            const txAccount = await program.account.transaction.fetch(
+                transaction.publicKey,
+                'confirmed'
+            );
+
+            const replacementKeys: Keypair[] = [];
+            let remainingAccounts: {
+                pubkey: PublicKey;
+                isSigner: boolean;
+                isWritable: boolean;
+            }[] = (txAccount.accounts as TransactionAccount[])
+                // Change the signer status on the vendor signer since it's signed by the program, not the client.
+                .map((meta) => {
+                    if (meta.pubkey.equals(multisigSigner)) {
+                        return { ...meta, isSigner: false }
+                    } else if (meta.pubkey.equals(ACCOUNT_REPLACEMENT_PLACEHOLDER)) {
+                        const replacementKey = Keypair.generate();
+                        replacementKeys.push(replacementKey);
+                        return { ...meta, pubkey: replacementKey.publicKey }
+                    }
+
+                    return meta
+                })
+                .concat({
+                    pubkey: txAccount.programId,
+                    isWritable: false,
+                    isSigner: false,
+                });
+
+            await program.methods
+                .executeTransactionWithReplacements(
+                    replacementKeys.map(k => k.publicKey)
+                )
+                .accounts({
+                    multisig: multisig.publicKey,
+                    multisigSigner: multisigSigner,
+                    transaction: transaction.publicKey,
+                    transactionDetail: txDetailAddress,
+                    payer: nonOwnerKey.publicKey,
+                    systemProgram: SystemProgram.programId,
+                })
+                .signers([nonOwnerKey]) // anyone can execute once it reaches the approval threshold
+                .remainingAccounts(remainingAccounts)
+                .signers(replacementKeys)
+                .rpc(
+                    {
+                        commitment: 'confirmed',
+                    }
+                );
+
+
+            const createdAccount = await provider.connection
+                .getAccountInfo(replacementKeys[0].publicKey, { commitment: 'confirmed' });
+            assert.exists(createdAccount);
+            assert.equal(createdAccount?.lamports, rent);
+            assert.equal(createdAccount?.data.length, 100);
+        } catch (error) {
+            console.log(error);
+            throw error;
+        }
+    });
+
+    it("fails to create proposal with not enough replacements", async () => {
+
+        const multisig = Keypair.generate();
+        const transaction = Keypair.generate();
+        const [txDetailAddress] = await PublicKey.findProgramAddress(
+            [multisig.publicKey.toBuffer(), transaction.publicKey.toBuffer()],
+            program.programId
+        );
+        const owner1Key = Keypair.generate();
+        await fundWallet(provider, owner1Key);
+        const label = 'Test';
+        const threshold = new BN(1);
+        const owners = [
+            {
+                address: owner1Key.publicKey,
+                name: "owner1"
+            },
+        ];
+        const [multisigSigner, nonce] = await PublicKey.findProgramAddress(
+            [multisig.publicKey.toBuffer()],
+            program.programId
+        );
+
+        // create transaction with multiple instructions
+        const rent = await provider.connection.getMinimumBalanceForRentExemption(100);
+
+        const ix1 = SystemProgram.createAccount({
+            /** The account that will transfer lamports to the created account */
+            fromPubkey: provider.wallet.publicKey,
+            /** Public key of the created account */
+            newAccountPubkey: ACCOUNT_REPLACEMENT_PLACEHOLDER,
+            /** Amount of lamports to transfer to the created account */
+            lamports: rent,
+            /** Amount of space in bytes to allocate to the created account */
+            space: 100,
+            /** Public key of the program to assign as the owner of the created account */
+            programId: SystemProgram.programId
+        });
+
+        const txSize = 1200;
+        const createIx = await program.account.transaction.createInstruction(
+            transaction,
+            txSize
+        );
+
+        const title = 'Test transaction';
+        const description = "This is a test transaction";
+        const operation = 1;
+
+        let expectedError: AnchorError | null = null;
+        try {
+
+            // create multisig
+            await program.methods
+                .createMultisig(owners, new BN(threshold), nonce, label)
+                .accounts({
+                    proposer: owner1Key.publicKey,
+                    multisig: multisig.publicKey,
+                    settings,
+                    opsAccount: MEAN_MULTISIG_OPS,
+                    systemProgram: SystemProgram.programId,
+                })
+                .signers([owner1Key, multisig])
+                .rpc();
+
+            // create proposal
+            await program.methods
+                .createTransaction(
+                    ix1.programId,
+                    ix1.keys.map(key => ({ pubkey: key.pubkey, isSigner: key.isSigner, isWritable: key.isWritable })),
+                    ix1.data,
+                    operation,
+                    title,
+                    description,
+                    new BN((new Date().getTime() / 1000) + 3600),
+                    new BN(0),
+                    255
+                )
+                .preInstructions([createIx])
+                .accounts({
+                    multisig: multisig.publicKey,
+                    transaction: transaction.publicKey,
+                    transactionDetail: txDetailAddress,
+                    proposer: owner1Key.publicKey,
+                    settings,
+                    opsAccount: MEAN_MULTISIG_OPS,
+                    systemProgram: SystemProgram.programId,
+                })
+                .signers([transaction, owner1Key])
+                .rpc({
+                    commitment: 'confirmed',
+                });
+
+            // approve proposal
+            await program.methods
+                .approve()
+                .accounts({
+                    multisig: multisig.publicKey,
+                    transaction: transaction.publicKey,
+                    transactionDetail: txDetailAddress,
+                    owner: owner1Key.publicKey,
+                    systemProgram: SystemProgram.programId,
+                })
+                .signers([owner1Key])
+                .rpc(
+                    {
+                        commitment: 'confirmed',
+                    }
+                );
+
+            // execute proposal tx with replacements
+            const txAccount = await program.account.transaction.fetch(
+                transaction.publicKey,
+                'confirmed'
+            );
+
+            const replacementKeys: Keypair[] = [];
+            let remainingAccounts: {
+                pubkey: PublicKey;
+                isSigner: boolean;
+                isWritable: boolean;
+            }[] = (txAccount.accounts as TransactionAccount[])
+                // Change the signer status on the vendor signer since it's signed by the program, not the client.
+                .map((meta) => {
+                    if (meta.pubkey.equals(multisigSigner)) {
+                        return { ...meta, isSigner: false }
+                    } else if (meta.pubkey.equals(ACCOUNT_REPLACEMENT_PLACEHOLDER)) {
+                        const replacementKey = Keypair.generate();
+                        replacementKeys.push(replacementKey);
+                        return { ...meta, pubkey: replacementKey.publicKey }
+                    }
+
+                    return meta
+                })
+                .concat({
+                    pubkey: txAccount.programId,
+                    isWritable: false,
+                    isSigner: false,
+                });
+
+            await program.methods
+                .executeTransactionWithReplacements(
+                    []
+                )
+                .accounts({
+                    multisig: multisig.publicKey,
+                    multisigSigner: multisigSigner,
+                    transaction: transaction.publicKey,
+                    transactionDetail: txDetailAddress,
+                    payer: nonOwnerKey.publicKey,
+                    systemProgram: SystemProgram.programId,
+                })
+                .signers([nonOwnerKey]) // anyone can execute once it reaches the approval threshold
+                .remainingAccounts(remainingAccounts)
+                .signers(replacementKeys)
+                .rpc(
+                    {
+                        commitment: 'confirmed',
+                    }
+                );
+            assert.fail("The statement above should fail")
+        } catch (error) {
+            // console.log(error);
+            expectedError = error as AnchorError;
+            assert.isNotEmpty(expectedError);
+            assert.strictEqual(expectedError?.error.errorCode.code, 'NotEnoughReplacementAccounts');
+            assert.strictEqual(expectedError?.error.errorCode.number, 6016);
+            assert.strictEqual(expectedError?.error.errorMessage, 'Not enough replacement accounts.');
+        }
+    });
+
+    it("updates settings", async () => {
         const newAuthority1Key = Keypair.generate();
         const newAuthority2Key = Keypair.generate();
         const newOpsAccountKey = Keypair.generate();
@@ -566,12 +910,12 @@ describe("multisig", async () => {
             new BN(newCreateMultisigFee),
             new BN(newCreateTransactionFee)
         )
-        .accounts({
-            authority: payer,
-            settings,
-            program: program.programId,
-            programData,
-        }).rpc({ commitment: "confirmed" });
+            .accounts({
+                authority: payer,
+                settings,
+                program: program.programId,
+                programData,
+            }).rpc({ commitment: "confirmed" });
 
         let settingsAccount = await program.account.settings.fetch(
             settings,
@@ -591,14 +935,14 @@ describe("multisig", async () => {
             new BN(newCreateMultisigFee),
             new BN(newCreateTransactionFee)
         )
-        .accounts({
-            authority: newAuthority1Key.publicKey,
-            settings,
-            program: program.programId,
-            programData,
-        })
-        .signers([newAuthority1Key])
-        .rpc({ commitment: "confirmed" });
+            .accounts({
+                authority: newAuthority1Key.publicKey,
+                settings,
+                program: program.programId,
+                programData,
+            })
+            .signers([newAuthority1Key])
+            .rpc({ commitment: "confirmed" });
 
         settingsAccount = await program.account.settings.fetch(
             settings,
@@ -614,14 +958,14 @@ describe("multisig", async () => {
             new BN(newCreateMultisigFee),
             new BN(newCreateTransactionFee)
         )
-        .accounts({
-            authority: payer,
-            settings,
-            program: program.programId,
-            programData,
-        })
-        // .signers([...]) // signed with payer authomatically by anchor
-        .rpc({ commitment: "confirmed" });
+            .accounts({
+                authority: payer,
+                settings,
+                program: program.programId,
+                programData,
+            })
+            // .signers([...]) // signed with payer authomatically by anchor
+            .rpc({ commitment: "confirmed" });
 
         settingsAccount = await program.account.settings.fetch(
             settings,
@@ -639,14 +983,14 @@ describe("multisig", async () => {
                 new BN(newCreateMultisigFee),
                 new BN(newCreateTransactionFee)
             )
-            .accounts({
-                authority: newAuthority1Key.publicKey,
-                settings,
-                program: program.programId,
-                programData,
-            })
-            .signers([newAuthority1Key])
-            .rpc({ commitment: "confirmed" });
+                .accounts({
+                    authority: newAuthority1Key.publicKey,
+                    settings,
+                    program: program.programId,
+                    programData,
+                })
+                .signers([newAuthority1Key])
+                .rpc({ commitment: "confirmed" });
             assert.fail("The statements above should fail");
         } catch (error) {
             // console.log(error);
@@ -656,7 +1000,7 @@ describe("multisig", async () => {
         assert.equal(expectedError?.error.errorCode.code, 'InvalidSettingsAuthority');
         assert.equal(expectedError?.error.errorCode.number, 6015);
         assert.equal(expectedError?.error.errorMessage, 'Invalid settings authority.');
-    })
+    });
 });
 
 describe("multisig-owners", async () => {


### PR DESCRIPTION
This ensures the multisig signer is a valid PDA and that is uses the canonical bump.

Also, replaced `execute_transaction_pda` with `execute_transaction_with_replacements`. The later allows creating proposals that require new accounts without specifying them until execution time.